### PR TITLE
Put it as a wrapper only (invariant from underlying modules)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+test:
+	@NODE_ENV=test ./node_modules/.bin/mocha \
+		--harmony \
+		--require should \
+		--reporter spec \
+		test.js

--- a/README.md
+++ b/README.md
@@ -1,6 +1,57 @@
 # co-bcrypt
 
-[bcryptjs](https://github.com/dcodeIO/bcrypt.js) wrapper for [co](https://github.com/visionmedia/co)
+Wrap bcrypt with generator goodness.
+
+We can wrap modules with [bcrypt](https://www.npmjs.org/package/bcrypt) compatible APIs, for example:
+
+- [nan-bcrypt](https://www.npmjs.org/package/nan-bcrypt)
+- [bcryptjs](https://github.com/dcodeIO/bcrypt.js)
+
+## Install
+
+```
+$ npm install co-bcrypt
+```
+
+## Setup
+
+Call `wrap()` on bcrypt module instances to make them generator friendly:
+
+```js
+// using nan-ified bcrypt (requires node 0.11.13)
+var module = require ('nan-bcrypt');
+
+// or the pure js version 
+// var module = require ('bcryptjs');
+
+var wrap = require ('co-bcrypt');
+var bcrypt = wrap(module);
+
+```
+
+## Example
+
+Simple example:
+
+```js	
+// inside co
+co(function * (){
+	var salt = yield bcrypt.genSalt();
+	var hash = yield bcrypt.hash('tobi', salt);
+	var compared = yield bcrypt.compare('tobi', hash);
+	console.log (salt, hash, compared);
+})();
+```
+
+## Test
+
+clone the repo, then:
+
+```
+$ cd co-bcrypt
+$ npm install 
+$ npm test
+```
 
 ## MIT License
 

--- a/index.js
+++ b/index.js
@@ -1,19 +1,36 @@
-var bcrypt = require('bcryptjs')
 
-exports.genSalt = function(rounds, seedLength) {
-  return function(done) {
-    bcrypt.genSalt(rounds, seedLength, done)
-  }
-}
+/**
+ * Module dependencies
+ */
 
-exports.hash = function(s, salt) {
-  return function(done) {
-    bcrypt.hash(s, salt, done)
-  }
-}
+var thunkify = require ('thunkify');
 
-exports.compare = function(s, hash) {
-  return function(done) {
-    bcrypt.compare(s, hash, done)
-  }
+/**
+ * Methods to wrap
+ */
+
+var methods = [
+	'genSalt',
+	'hash',
+	'compare'
+];
+
+/**
+ * Wrap `bcrypt` 
+ *
+ * @param {BCrypt} native or pure js version
+ * @return {WrappedBCrypt}
+ * @api public
+ */
+
+module.exports = function (bcrypt) {
+	var obj = {};
+	for (var k in bcrypt) {
+		if (methods.indexOf(k) >= 0) {
+			obj[k] = thunkify(bcrypt[k]);
+		} else {
+			obj[k] = bcrypt[k];
+		}
+	}
+	return obj;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "co-bcrypt",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Markus Ast <npm.m@rkusa.st>",
   "description": "bcryptjs wrapper for co",
   "keywords": [
@@ -16,9 +16,11 @@
   ],
   "homepage": "https://github.com/rkusa/co-bcrypt",
   "dependencies": {
-    "bcryptjs": "^0.7.12"
+    "thunkify": "^2.1.1"
   },
-  "bugs": "https://github.com/rkusa/co-bcrypt/issues",
+  "bugs": {
+    "url": "https://github.com/rkusa/co-bcrypt/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/rkusa/co-bcrypt.git"
@@ -26,5 +28,16 @@
   "license": "MIT",
   "engines": {
     "node": ">=0.11.2"
+  },
+  "devDependencies": {
+    "bcryptjs": "^0.7.12",
+    "co": "^3.0.6",
+    "mocha": "^1.20.0",
+    "nan-bcrypt": "^0.7.9",
+    "should": "^4.0.0"
+  },
+  "main": "index.js",
+  "scripts": {
+    "test": "make test"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,44 @@
+
+/**
+ * Module dependencies
+ */
+
+var nan = require ('nan-bcrypt');
+var js = require ('bcryptjs');
+var wrap = require ('./');
+var co = require ('co');
+
+/**
+ * Using nan-bcrypt
+ */
+
+describe ('wrap nan-bcrypt', function(){
+	it ('should work', function(done){
+		co(function * (){
+			var bcrypt = wrap(nan);
+			var salt = yield bcrypt.genSalt();
+			var hash = yield bcrypt.hash('tobi', salt);
+			var compared = yield bcrypt.compare('tobi', hash);
+			compared.should.equal(true);
+		})(done);
+	});
+});
+
+/**
+ * Using bcryptjs
+ */
+
+describe ('wrap bcryptjs', function(){
+	it ('should work', function(done){
+		co(function * (){
+			var bcrypt = wrap(js);
+			var salt = yield bcrypt.genSalt();
+			var hash = yield bcrypt.hash('tobi', salt);
+			var compared = yield bcrypt.compare('tobi', hash);
+			compared.should.equal(true);
+		})(done);
+	});
+});
+
+
+


### PR DESCRIPTION
Proposed changes:
- Convert  it as a wrapper only (invariant from underlying modules), hence we can swap the underlying `bcrypt` modules (native, or pure js) accordingly
- Add setup dan example on `README`
- Add some tests using `co` and `mocha` as its runner

Quick look on the API

``` js

// e.g. using nan-bcrypt
var mod = require ('nan-bcrypt');

// or using pure js
// var mod = require ('bcryptjs');

co(function * (){
  var bcrypt = wrap(nan);
  var salt = yield bcrypt.genSalt();
  var hash = yield bcrypt.hash('tobi', salt);
  var compared = yield bcrypt.compare('tobi', hash);
})(done);
```
